### PR TITLE
adds ssh-rsa to accepted public key types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## Unreleased
+- Explicitly add `ssh-rsa` to the `PubkeyAcceptedKeyTypes`; supposed fix for Fivetran connectors using SSH Tunneling
+
+
+
+## v1.1
+- upgrade base image to alpine 3.16, [d285417](https://github.com/dbl-works/bastion/commit/d285417179de405f2f9560b5a7f549d385efe5c4)
+
+
+
+## v1.0
+Initial Release

--- a/README.md
+++ b/README.md
@@ -35,3 +35,8 @@ aws ecr get-login-password --profile $AWS_PROFILE --region $AWS_REGION | docker 
 docker tag localhost/bastion $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/bastion:$LATEST_RELEASE
 docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/bastion:$LATEST_RELEASE
 ```
+
+
+## Further Reads
+
+sshd config: https://manpages.ubuntu.com/manpages/xenial/man5/sshd_config.5.html

--- a/README.md
+++ b/README.md
@@ -5,8 +5,22 @@ https://hub.docker.com/r/dblworks/bastion
 
 ## Building
 
+On a x86 chip
 ```shell
-docker build -t localhost/bastion .
+docker build -t dblworks/bastion:$TAGNAME .
+```
+
+On a ARM chip (for a x86 target):
+
+```shell
+docker build -t dblworks/bastion:$TAGNAME . --platform amd64
+```
+
+
+## Publishing
+
+```shell
+docker push dblworks/bastion:$TAGNAME
 ```
 
 

--- a/sshd_config
+++ b/sshd_config
@@ -2,6 +2,7 @@ PasswordAuthentication no
 PermitEmptyPasswords no
 
 PubkeyAcceptedKeyTypes +ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
+HostkeyAlgorithms +ssh-rsa
 
 Match User root
   AllowTcpForwarding yes

--- a/sshd_config
+++ b/sshd_config
@@ -1,6 +1,8 @@
 PasswordAuthentication no
 PermitEmptyPasswords no
 
+PubkeyAcceptedKeyTypes +ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-rsa,ssh-dss
+
 Match User root
   AllowTcpForwarding yes
   X11Forwarding no


### PR DESCRIPTION
[Fivetran](https://fivetran.com) throws **Unable to connect to SSH tunnel Algorithm negotiation fail** when trying to connect through this bastion host.

Their support suggests to explicitly allow `ssh-rsa` as a public key type.


NOTE: the MAN pages for sshd for Alpine do not list the PubkeyAcceptedKeyTypes option, however, this source suggests this option to be present: https://github.com/hadronzoo/alpine-ssh/blob/master/Dockerfile


This branch is published to docker hub as tag `nightly`: https://hub.docker.com/repository/docker/dblworks/bastion


# Testing connection to an RDS that is in a private subnet with access through bastion
## before

<img width="623" alt="image" src="https://user-images.githubusercontent.com/20702503/188285104-e426ae1d-840a-468a-8946-ae7ac2681888.png">


## after
<img width="596" alt="image" src="https://user-images.githubusercontent.com/20702503/188285100-b437024f-60d9-41a3-a04a-223ba7102f7a.png">
